### PR TITLE
#11 Change pair key in paris list

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ for (let [i, loginData] of CONFIG.logins.entries()) {
 	}
 
 	const bot = botController.addBot(loginData, settings); // RETURN bot
-	pairs.push({ bot: bot.id, proxy });                    // COLLECT pair
+	pairs.push({ bot: bot.loginData.accountName, proxy });                    // COLLECT pair
 }
 
 const scheduler = new PairScheduler(pairs);


### PR DESCRIPTION
Update logic of pairs list creation to use Account name as pair key instead of unidentefied bot.id